### PR TITLE
option to exclude abs attributes

### DIFF
--- a/stitch/__init__.py
+++ b/stitch/__init__.py
@@ -87,8 +87,10 @@ class StitchEndpoint(object):
         self._headers = headers
         self._resource = resource
 
-    def _request(self, action, data):
+    def _request(self, action, data, exclude_abs_attrs=False):
         data['action'] = action[0]
+        if action == self.READ and exclude_abs_attrs:
+            data['exclude_absolute_attributes'] = True
         uri = action[1] % self._resource
         data = json.dumps(data)
         try:
@@ -117,7 +119,7 @@ class StitchEndpoint(object):
         else:
             raise StitchException('STATUS:%s URL:%s DATA:%s RESPONSE:%s' % (response.status_code, uri, data, response.content))
 
-    def _list(self, page_num=1, page_size=20, filter_=None, sort_=None):
+    def _list(self, page_num=1, page_size=20, filter_=None, sort_=None, exclude_abs_attrs=False):
         data = {
             'page_num': page_num,
             'page_size': page_size,
@@ -126,14 +128,14 @@ class StitchEndpoint(object):
         }
         return self._request(self.READ, data)
 
-    def page(self, page_num=1, page_size=20, filter_=None, sort_=None):
-        return self._list(page_num, page_size, filter_, sort_)
+    def page(self, page_num=1, page_size=20, filter_=None, sort_=None, exclude_abs_attrs=False):
+        return self._list(page_num, page_size, filter_, sort_, exclude_abs_attrs)
 
     def page_count(self, page_size=20, filter_=None):
-        return int(self._list(page_size=page_size, filter_=filter_).meta['last_page'])
+        return int(self._list(page_size=page_size, filter_=filter_, exclude_abs_attrs=True).meta['last_page'])
 
     def count(self, filter_=None):
-        return int(self._list(page_size=1, filter_=filter_).meta['total'])
+        return int(self._list(page_size=1, filter_=filter_, exclude_abs_attrs=True).meta['total'])
 
     def _reports(self, page_num=1, page_size=20, filter_=None, sort_=None, **kwargs):
         data = {

--- a/stitch/__init__.py
+++ b/stitch/__init__.py
@@ -126,7 +126,7 @@ class StitchEndpoint(object):
             'filter': filter_ or {},
             'sort': sort_ or {}
         }
-        return self._request(self.READ, data)
+        return self._request(self.READ, data, exclude_abs_attrs)
 
     def page(self, page_num=1, page_size=20, filter_=None, sort_=None, exclude_abs_attrs=False):
         return self._list(page_num, page_size, filter_, sort_, exclude_abs_attrs)


### PR DESCRIPTION
As per Stitch:

We have added a new parameter to our standard api that will exclude all of the calculated values from a list or detail response. If you don't use any of them or can get around them, it should improve performance quite a bit depending on the call.

The parameter is "exclude_absolute_attributes" and it just needs to be added to any standard api read request top level in the post body and set to 1 or true.

So if you were making a sales order list call you would have this as the post body:
{
    "action": "read",
    "exclude_absolute_attributes": "1"
}

You can still add any other filters or sorting that you need.

Here are the values for the objects that you use that will be removed:

## Products
- "committed_stock"
- "group_category"
- "low_stock_count"
- "total_available"
- "total_revenue"
- "total_sold"
- "total_stock"
- "variant_count"

## PurchaseOrders
- "drop_shipping"
- "num_dropshippable_line_items"

## SalesOrders
- "acknowledged"
- "is_open"
- "is_order_fulfillment_criteria_valid"
- "is_pending"
- "is_pos"
- "limbo_order_product_connect_sku_id"
- "locked"
- "order_fulfillment_status_errors"
- "supplier_meta_data"
- "total_paid_balance"
- "unfulfillable_reasons"
- "warehouse_meta_data"

## Variants
- "committed_stock"
- "drop_shippable"
- "primary_supplier"
- "reorder_awaiting_stock"
- "reorder_stock"
- "stock_out"
- "supplier_cost"
- "supplier_id"
- "total_revenue"
- "total_sold"
- "warehouse_address_id"
- "warehouse_available"


This will also remove these values from linked objects for any standard api request that is including these objects as linked objects. 